### PR TITLE
Local storage

### DIFF
--- a/manup-demo/package.json
+++ b/manup-demo/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-server": "2.2.1",
     "@ionic/storage": "1.1.7",
     "ionic-angular": "2.0.0",
-    "ionic-manup": "^0.0.5",
+    "ionic-manup": "^0.1.0",
     "ionic-native": "2.4.1",
     "ionicons": "3.0.0",
     "ng2-translate": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@angular/platform-browser": "^2.2.1",
     "@angular/platform-browser-dynamic": "^2.2.1",
     "@angular/platform-server": "^2.2.1",
+    "@ionic/storage": "^1.1.9",
     "@types/jasmine": "^2.5.41",
     "@types/node": "^7.0.5",
     "@types/semver": "^5.3.30",

--- a/src/manup.config.ts
+++ b/src/manup.config.ts
@@ -1,7 +1,23 @@
 import { Injectable } from '@angular/core';
 
 @Injectable()
+/**
+ * Configuration values for ManUp
+ */
 export class ManUpConfig {
+    /**
+     * The metadata URL to read version info from.
+     * 
+     * @type {string}
+     * @memberOf ManUpConfig
+     */
     url: string
+
+    /**
+     * Whether to assume translations will be provided to the module.
+     * 
+     * @type {boolean}
+     * @memberOf ManUpConfig
+     */
     externalTranslations?: boolean;
 }

--- a/src/manup.service.ts
+++ b/src/manup.service.ts
@@ -68,10 +68,10 @@ export class ManUpService {
      */
     public AppVersion: any = AppVersion;
 
-    public constructor(private http: Http, 
+    public constructor(private config: ManUpConfig, 
+                       private http: Http, 
                        private alert: AlertController, 
                        private platform: Platform, 
-                       private config: ManUpConfig, 
                        @Optional() private translate: TranslateService,
                        @Optional() private storage: Storage) {
 
@@ -151,7 +151,8 @@ export class ManUpService {
      * Fetches the remote metadata and returns an observable with the json
      */
     public metadata(): Observable<ManUpData> {
-        return this.http.get(this.config.url).map(response => response.json())
+        return this.http.get(this.config.url).map(response => response.json());
+        /*
         .map(response => {
             if (this.storage) {
                 return this.saveMetadata(response)
@@ -164,6 +165,7 @@ export class ManUpService {
             }
             return err;
         });
+        */
     }
 
 
@@ -176,9 +178,9 @@ export class ManUpService {
      * 
      * @memberOf ManUpService
      */
-    private metadataFromStorage(): Observable<ManUpData> {
+    metadataFromStorage(): Observable<ManUpData> {
         if (this.storage) {
-            return Observable.fromPromise((<Promise<string>> this.storage.get('asdf'))).map(v=> JSON.parse(v))
+            return Observable.fromPromise((<Promise<string>> this.storage.get(STORAGE_KEY + '.manup'))).map(v=> JSON.parse(v));
         }
         else {
             throw new Error('Storage not configured');
@@ -196,7 +198,7 @@ export class ManUpService {
      * 
      * @memberOf ManUpService
      */
-    private saveMetadata(metadata: ManUpData): Promise<any> {
+    public saveMetadata(metadata: ManUpData): Promise<any> {
         if (this.storage) {
             return this.storage.set(STORAGE_KEY + '.manup', JSON.stringify(metadata));
         }

--- a/src/manup.service.ts
+++ b/src/manup.service.ts
@@ -151,7 +151,19 @@ export class ManUpService {
      * Fetches the remote metadata and returns an observable with the json
      */
     public metadata(): Observable<ManUpData> {
-        return this.http.get(this.config.url).map(response => response.json());
+        return this.http.get(this.config.url).map(response => response.json())
+        .map(response => {
+            if (this.storage) {
+                return this.saveMetadata(response)
+            }
+            return response;
+        })
+        .catch(err => {
+            if (this.storage) {
+                return this.metadataFromStorage();
+            }
+            return err;
+        });
     }
 
 

--- a/src/manup.service.ts
+++ b/src/manup.service.ts
@@ -117,7 +117,8 @@ export class ManUpService {
                                 default:
                                     return this.presentAlert(alert, metadata);
                             }
-                        })
+                        },
+                        error => resolve());
                     });
                 })
             });

--- a/src/manup.service.ts
+++ b/src/manup.service.ts
@@ -4,6 +4,7 @@ import { Http } from '@angular/http';
 import { Injectable, Optional } from '@angular/core';
 import { AppVersion, InAppBrowser } from 'ionic-native';
 import { Observable } from 'rxjs';
+import { Storage } from '@ionic/storage';
 
 import 'rxjs/add/operator/map';
 
@@ -54,7 +55,7 @@ export interface ManUpData {
 export class ManUpService {
     public AppVersion: any = AppVersion;
 
-    public constructor(private http: Http, private alert: AlertController, private platform: Platform, private config: ManUpConfig) {}
+    public constructor(private http: Http, private alert: AlertController, private platform: Platform, private config: ManUpConfig, @Optional() private storage: Storage) {}
 
     /**
      * True if there is an alert already displayed. Used to prevent multiple alerts 

--- a/src/manup.service.ts
+++ b/src/manup.service.ts
@@ -52,9 +52,9 @@ export interface PlatformData {
  * What the metadata object should look like
  */
 export interface ManUpData {
-    ios: PlatformData;
-    android: PlatformData;
-    windows: PlatformData;
+    ios?: PlatformData;
+    android?: PlatformData;
+    windows?: PlatformData;
 }
 
 @Injectable()

--- a/src/manup.service.ts
+++ b/src/manup.service.ts
@@ -10,6 +10,7 @@ import { Storage } from '@ionic/storage';
 import { i18n } from './i18n';
 
 import 'rxjs/add/operator/map';
+import 'rxjs/add/observable/fromPromise';
 
 import * as semver from 'semver';
 
@@ -103,7 +104,6 @@ export class ManUpService {
         if (!this.inProgress) {
             this.inProgress = true;
             this.currentPromise = new Promise( (resolve, reject) => {
-                console.log('waiting for platform');
                 this.platform.ready()
                 .then( () => {
                     this.metadata()
@@ -164,9 +164,9 @@ export class ManUpService {
      * 
      * @memberOf ManUpService
      */
-    private metadataFromStorage(): Promise<any> {
+    private metadataFromStorage(): Observable<ManUpData> {
         if (this.storage) {
-            return this.storage.get(STORAGE_KEY + '.manup').then((item:string) => JSON.parse(item));
+            return Observable.fromPromise((<Promise<string>> this.storage.get('asdf'))).map(v=> JSON.parse(v))
         }
         else {
             throw new Error('Storage not configured');

--- a/src/manup.service.ts
+++ b/src/manup.service.ts
@@ -152,11 +152,10 @@ export class ManUpService {
      * Fetches the remote metadata and returns an observable with the json
      */
     public metadata(): Observable<ManUpData> {
-        return this.http.get(this.config.url).map(response => response.json());
-        /*
+        return this.http.get(this.config.url).map(response => response.json())
         .map(response => {
             if (this.storage) {
-                return this.saveMetadata(response)
+                this.saveMetadata(response).catch( () => {});
             }
             return response;
         })
@@ -166,7 +165,6 @@ export class ManUpService {
             }
             return err;
         });
-        */
     }
 
 

--- a/src/manup.spec.ts
+++ b/src/manup.spec.ts
@@ -17,7 +17,7 @@ describe('Manup Spec', function() {
                 enabled: false
             };
 
-            let manup = new ManUpService(null, null, null, null);
+            let manup = new ManUpService(null, null, null, null, null);
             manup.AppVersion = MockAppVersion;
 
             manup.evaluate(json).then(function(alert) {
@@ -33,7 +33,7 @@ describe('Manup Spec', function() {
                 enabled: true 
             };
 
-            let manup = new ManUpService(null, null, null, null);
+            let manup = new ManUpService(null, null, null, null, null);
             manup.AppVersion = MockAppVersion;
 
             manup.evaluate(json).then(function(alert) {
@@ -49,7 +49,7 @@ describe('Manup Spec', function() {
                 enabled: true 
             };
 
-            let manup = new ManUpService(null, null, null, null);
+            let manup = new ManUpService(null, null, null, null, null);
             manup.AppVersion = MockAppVersion;
 
             manup.evaluate(json).then(function(alert) {
@@ -65,7 +65,7 @@ describe('Manup Spec', function() {
                 enabled: true 
             };
 
-            let manup = new ManUpService(null, null, null, null);
+            let manup = new ManUpService(null, null, null, null, null);
             manup.AppVersion = MockAppVersion;
 
             manup.evaluate(json).then(function(alert) {
@@ -103,7 +103,7 @@ describe('Manup Spec', function() {
                     return v === 'ios'
                 }
             };
-            let manup = new ManUpService(null, null, <any> mockPlatform, null);
+            let manup = new ManUpService(null, null, <any> mockPlatform, null, null);
 
             let result = manup.getPlatformData(json);
             expect(result).toEqual(json.ios);
@@ -115,7 +115,7 @@ describe('Manup Spec', function() {
                     return v === 'android'
                 }
             };
-            let manup = new ManUpService(null, null, <any> mockPlatform, null);
+            let manup = new ManUpService(null, null, <any> mockPlatform, null, null);
 
             let result = manup.getPlatformData(json);
             expect(result).toEqual(json.android);
@@ -127,7 +127,7 @@ describe('Manup Spec', function() {
                     return v === 'windows'
                 }
             };
-            let manup = new ManUpService(null, null, <any> mockPlatform, null);
+            let manup = new ManUpService(null, null, <any> mockPlatform, null, null);
 
             let result = manup.getPlatformData(json);
             expect(result).toEqual(json.windows);
@@ -139,7 +139,7 @@ describe('Manup Spec', function() {
                     return false;
                 }
             };
-            let manup = new ManUpService(null, null, <any> mockPlatform, null);
+            let manup = new ManUpService(null, null, <any> mockPlatform, null, null);
 
             expect( () => {manup.getPlatformData(json)}).toThrow();
         })

--- a/src/manup.spec.ts
+++ b/src/manup.spec.ts
@@ -17,7 +17,7 @@ describe('Manup Spec', function() {
                 enabled: false
             };
 
-            let manup = new ManUpService(null, null, null, null, null);
+            let manup = new ManUpService(null, null, null, null, null,null);
             manup.AppVersion = MockAppVersion;
 
             manup.evaluate(json).then(function(alert) {
@@ -33,7 +33,7 @@ describe('Manup Spec', function() {
                 enabled: true 
             };
 
-            let manup = new ManUpService(null, null, null, null, null);
+            let manup = new ManUpService(null, null, null, null, null,null);
             manup.AppVersion = MockAppVersion;
 
             manup.evaluate(json).then(function(alert) {
@@ -49,7 +49,7 @@ describe('Manup Spec', function() {
                 enabled: true 
             };
 
-            let manup = new ManUpService(null, null, null, null, null);
+            let manup = new ManUpService(null, null, null, null, null,null);
             manup.AppVersion = MockAppVersion;
 
             manup.evaluate(json).then(function(alert) {
@@ -65,7 +65,7 @@ describe('Manup Spec', function() {
                 enabled: true 
             };
 
-            let manup = new ManUpService(null, null, null, null, null);
+            let manup = new ManUpService(null, null, null, null, null,null);
             manup.AppVersion = MockAppVersion;
 
             manup.evaluate(json).then(function(alert) {
@@ -103,7 +103,7 @@ describe('Manup Spec', function() {
                     return v === 'ios'
                 }
             };
-            let manup = new ManUpService(null, null, <any> mockPlatform, null, null);
+            let manup = new ManUpService(null, null, <any> mockPlatform, null, null,null);
 
             let result = manup.getPlatformData(json);
             expect(result).toEqual(json.ios);
@@ -115,7 +115,7 @@ describe('Manup Spec', function() {
                     return v === 'android'
                 }
             };
-            let manup = new ManUpService(null, null, <any> mockPlatform, null, null);
+            let manup = new ManUpService(null, null, <any> mockPlatform, null, null,null);
 
             let result = manup.getPlatformData(json);
             expect(result).toEqual(json.android);
@@ -127,7 +127,7 @@ describe('Manup Spec', function() {
                     return v === 'windows'
                 }
             };
-            let manup = new ManUpService(null, null, <any> mockPlatform, null, null);
+            let manup = new ManUpService(null, null, <any> mockPlatform, null, null,null);
 
             let result = manup.getPlatformData(json);
             expect(result).toEqual(json.windows);
@@ -139,7 +139,7 @@ describe('Manup Spec', function() {
                     return false;
                 }
             };
-            let manup = new ManUpService(null, null, <any> mockPlatform, null, null);
+            let manup = new ManUpService(null, null, <any> mockPlatform, null, null,null);
 
             expect( () => {manup.getPlatformData(json)}).toThrow();
         })


### PR DESCRIPTION
Manup saves the metadata to local storage. If the remote server cannot be reached, manup uses the latest version saved in storage.

Uses ionic-native/storage if available. Works as before if app does not use storage.