### PR TITLE
Update demo instructions in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ A demonstration app is in the `manup-demo` folder. This is the default Ionic 2 s
 
 ```sh
 cd manup-demo
-ionic emulate ios
+ionic cordova emulate ios
 ```
 
 Assuming you have Ionic installed.


### PR DESCRIPTION
Wanted to give the module a try, so did a clone, installed ionic, tried to run it but received this error:
```
$ ionic emulate ios
The emulate command has been renamed. To find out more, run:

  ionic cordova emulate --help
```

I believe the solution is:
```
ionic cordova emulate ios
```

That would get the project running in a simulator. Append `--target="iPhone-X"` for the latest and greatest. 

NB: Once the app launched in the simulator, no ManUp alerts appeared. I am not sure if I got it running correctly.
