### PR TITLE
bugfix: resolve promise when alert is dismissed

### DIFF
--- a/src/manup.service.ts
+++ b/src/manup.service.ts
@@ -139,8 +139,10 @@ export class ManUpService {
                 case AlertType.NOP:
                   resolve();
                   break;
-                default:
-                  return this.presentAlert(result, platformData);
+                default: {
+                  await this.presentAlert(result, platformData);
+                  resolve();
+                }
               }
             } catch (e) {
               return resolve();


### PR DESCRIPTION
For optional updates, the `manup.validate()` promise was not resolving when user dismisses the alert by clicking "Not now".
As a consequence, users were unable to use keep using the app without installing **optional** updates, which is not intended behaviour.

This pull request tries to fix that.